### PR TITLE
match nullable specs on PreparedStatementCommonExt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,3 +127,7 @@ tasks.named("dependencyUpdates").configure {
         isNonStable(it.candidate.version)
     }
 }
+
+rootProject.plugins.withType(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin) {
+    rootProject.extensions.getByType(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension).nodeVersion = "16.15.1"
+}

--- a/door-compiler/src/main/kotlin/com/ustadmobile/lib/annotationprocessor/core/CodeBlockExt.kt
+++ b/door-compiler/src/main/kotlin/com/ustadmobile/lib/annotationprocessor/core/CodeBlockExt.kt
@@ -255,13 +255,13 @@ fun CodeBlock.Builder.addGetResultOrSetQueryParamCall(
             MemberName(extPkgName, "${operation}LongNullable"))
         type == builtIns.floatType -> add("${operation}Float")
         type == builtIns.floatType.makeNullable() -> add("%M",
-            MemberName(extPkgName,"${operation}Float"))
+            MemberName(extPkgName,"${operation}FloatNullable"))
         type == builtIns.doubleType -> add("${operation}Double")
         type == builtIns.doubleType.makeNullable() -> add("%M",
-            MemberName(extPkgName, "${operation}Double"))
+            MemberName(extPkgName, "${operation}DoubleNullable"))
         type == builtIns.booleanType -> add("${operation}Boolean")
         type == builtIns.booleanType.makeNullable() -> add("%M",
-            MemberName(extPkgName, "${operation}Boolean"))
+            MemberName(extPkgName, "${operation}BooleanNullable"))
         type.equalsIgnoreNullable(builtIns.stringType) -> add("${operation}String")
         type == builtIns.arrayType -> add("${operation}Array")
         (type.declaration as? KSClassDeclaration)?.isListDeclaration() == true -> add("${operation}Array")

--- a/door-runtime/build.gradle
+++ b/door-runtime/build.gradle
@@ -38,6 +38,10 @@ android {
 
 }
 
+rootProject.plugins.withType(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin) {
+    rootProject.extensions.getByType(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension).nodeVersion = "16.15.1"
+}
+
 kotlin {
     //This is essential: if this is removed, then expect/actual typealias resolution breaks on Android compilation.
     androidTarget {

--- a/door-runtime/build.gradle
+++ b/door-runtime/build.gradle
@@ -38,10 +38,6 @@ android {
 
 }
 
-rootProject.plugins.withType(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin) {
-    rootProject.extensions.getByType(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension).nodeVersion = "16.15.1"
-}
-
 kotlin {
     //This is essential: if this is removed, then expect/actual typealias resolution breaks on Android compilation.
     androidTarget {


### PR DESCRIPTION
The code generated for an entity like below tries to call the  setDouble/getDouble for nullable entries:

```kotlin
@Entity
data class Invoice(
    @PrimaryKey var sale_id: Long,
    var contract_id: Long? = null,
    var date_create: Long,
    var date_payment: Long? = null,
    var date_update: Long? = null,
    var sale_status: Int,
    var sale_status_name: String? = null,
    var sale_item_id: Long? = null,
    var sale_item_discount: Double? = null,
    ...
}
```

The fix on the f6ab80d71772a3e4d19ae804b52c853b82667fa4 commit makes it match the extension functions in [commonMain/com/ustadmobile/door/jdbc/ext/PreparedStatementCommonExt.kt](https://github.com/UstadMobile/door/blob/main/door-runtime/src/commonMain/kotlin/com/ustadmobile/door/jdbc/ext/PreparedStatementCommonExt.kt). 

The subsequent commits were needed in order to build on jitpack so I could minimally test the fix - I did so in a kotlin/jvm only project in which I'm using door. Fee free to ditch these if unneeded.